### PR TITLE
Fix scroll bug on arrow key presses

### DIFF
--- a/script.js
+++ b/script.js
@@ -157,6 +157,16 @@ function move(direction) {
 }
 
 function handleKeyPress(event) {
+    if ([
+        'ArrowLeft',
+        'ArrowRight',
+        'ArrowUp',
+        'ArrowDown'
+    ].includes(event.key)) {
+        // Prevent the page from scrolling when using arrow keys
+        event.preventDefault();
+    }
+
     switch(event.key) {
         case 'ArrowLeft':
             move('left');


### PR DESCRIPTION
## Summary
- prevent arrow keys from scrolling the page while playing

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -s http://localhost:8000/index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_6842bbc69be083238ea8efdbad302b99