### PR TITLE
Add sliding animation to tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,13 +11,8 @@
         <div class="score-container">
             <h2>Score: <span id="score">0</span></h2>
         </div>
-        <div class="tile-container">
-            <div class="tile" data-value=""></div>
-            <div class="tile" data-value=""></div>
-            <div class="tile" data-value=""></div>
-            <div class="tile" data-value=""></div>
-            <div class="tile" data-value=""></div>
-       </div>
+        <div class="grid-container" id="grid-container"></div>
+        <div class="tile-container" id="tile-container"></div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,181 +1,180 @@
 const GRID_SIZE = 5;
-const grid = Array(GRID_SIZE).fill().map(() => Array(GRID_SIZE).fill(0));
-const tileContainer = document.querySelector('.tile-container');
+const CELL_SIZE = 80;
+const CELL_GAP = 10;
+
+const gridContainer = document.getElementById('grid-container');
+const tileContainer = document.getElementById('tile-container');
 const scoreDisplay = document.getElementById('score');
+
+let grid = [];
+let tiles = []; // {row, col, value, element, merged}
 let score = 0;
 
-function createTiles() {
-    // Clear existing tiles
-    tileContainer.innerHTML = '';
-    
-    // Create exactly GRID_SIZE * GRID_SIZE tiles
-    const totalTiles = GRID_SIZE * GRID_SIZE;
-    for (let i = 0; i < totalTiles; i++) {
-        const tile = document.createElement('div');
-        tile.classList.add('tile');
-        tile.setAttribute('data-value', '');
-        tileContainer.appendChild(tile);
-    }
+function createGrid() {
+  for (let i = 0; i < GRID_SIZE * GRID_SIZE; i++) {
+    const cell = document.createElement('div');
+    cell.classList.add('cell');
+    gridContainer.appendChild(cell);
+  }
 }
 
-function updateDisplay() {
-    const tiles = document.querySelectorAll('.tile');
-    for (let i = 0; i < GRID_SIZE; i++) {
-        for (let j = 0; j < GRID_SIZE; j++) {
-            const index = i * GRID_SIZE + j;
-            const value = grid[i][j];
-            tiles[index].textContent = value || '';
-            tiles[index].setAttribute('data-value', value || '');
-        }
-    }
-    scoreDisplay.textContent = score;
+function positionTile(el, row, col) {
+  const x = col * (CELL_SIZE + CELL_GAP);
+  const y = row * (CELL_SIZE + CELL_GAP);
+  el.style.transform = `translate(${x}px, ${y}px)`;
 }
 
-function addNewTile() {
-    const emptyCells = [];
-    for (let i = 0; i < GRID_SIZE; i++) {
-        for (let j = 0; j < GRID_SIZE; j++) {
-            if (grid[i][j] === 0) {
-                emptyCells.push({i, j});
-            }
-        }
+function createTile(value, row, col) {
+  const div = document.createElement('div');
+  div.classList.add('tile');
+  div.textContent = value;
+  div.dataset.value = value;
+  positionTile(div, row, col);
+  tileContainer.appendChild(div);
+  return { row, col, value, element: div };
+}
+
+function spawnTile() {
+  const empty = [];
+  for (let i = 0; i < GRID_SIZE; i++) {
+    for (let j = 0; j < GRID_SIZE; j++) {
+      if (grid[i][j] === 0) empty.push({ i, j });
     }
-    if (emptyCells.length > 0) {
-        const {i, j} = emptyCells[Math.floor(Math.random() * emptyCells.length)];
-        grid[i][j] = Math.random() < 0.9 ? 2 : 4;
-    }
+  }
+  if (!empty.length) return;
+  const { i, j } = empty[Math.floor(Math.random() * empty.length)];
+  const value = Math.random() < 0.9 ? 2 : 4;
+  grid[i][j] = value;
+  tiles.push(createTile(value, i, j));
+}
+
+function updateScore() {
+  scoreDisplay.textContent = score;
+}
+
+function resetGrid() {
+  grid = Array(GRID_SIZE)
+    .fill()
+    .map(() => Array(GRID_SIZE).fill(0));
 }
 
 function move(direction) {
-    let moved = false;
-    const tempGrid = grid.map(row => [...row]);
+  tiles.forEach((t) => {
+    delete t.merged;
+    delete t.toRemove;
+  });
 
-    if (direction === 'left') {
-        // Move left
-        for (let i = 0; i < GRID_SIZE; i++) {
-            let row = grid[i].filter(cell => cell !== 0);
-            
-            // Merge
-            for (let j = 0; j < row.length - 1; j++) {
-                if (row[j] === row[j + 1]) {
-                    row[j] *= 2;
-                    score += row[j];
-                    row.splice(j + 1, 1);
-                }
-            }
-            
-            // Fill with zeros at the end
-            while (row.length < GRID_SIZE) {
-                row.push(0);
-            }
-            grid[i] = row;
-        }
-    } else if (direction === 'right') {
-        // Move right
-        for (let i = 0; i < GRID_SIZE; i++) {
-            let row = grid[i].filter(cell => cell !== 0);
-            
-            // Merge from right to left
-            for (let j = row.length - 1; j > 0; j--) {
-                if (row[j] === row[j - 1]) {
-                    row[j] *= 2;
-                    score += row[j];
-                    row.splice(j - 1, 1);
-                }
-            }
-            
-            // Fill with zeros at the start
-            while (row.length < GRID_SIZE) {
-                row.unshift(0);
-            }
-            grid[i] = row;
-        }
-    } else if (direction === 'up') {
-        // Move up
-        for (let j = 0; j < GRID_SIZE; j++) {
-            let col = grid.map(row => row[j]).filter(cell => cell !== 0);
-            
-            // Merge
-            for (let i = 0; i < col.length - 1; i++) {
-                if (col[i] === col[i + 1]) {
-                    col[i] *= 2;
-                    score += col[i];
-                    col.splice(i + 1, 1);
-                }
-            }
-            
-            // Fill with zeros at the end
-            while (col.length < GRID_SIZE) {
-                col.push(0);
-            }
-            
-            // Update the column in the grid
-            for (let i = 0; i < GRID_SIZE; i++) {
-                grid[i][j] = col[i];
-            }
-        }
-    } else if (direction === 'down') {
-        // Move down
-        for (let j = 0; j < GRID_SIZE; j++) {
-            let col = grid.map(row => row[j]).filter(cell => cell !== 0);
-            
-            // Merge from bottom to top
-            for (let i = col.length - 1; i > 0; i--) {
-                if (col[i] === col[i - 1]) {
-                    col[i] *= 2;
-                    score += col[i];
-                    col.splice(i - 1, 1);
-                }
-            }
-            
-            // Fill with zeros at the start
-            while (col.length < GRID_SIZE) {
-                col.unshift(0);
-            }
-            
-            // Update the column in the grid
-            for (let i = 0; i < GRID_SIZE; i++) {
-                grid[i][j] = col[i];
-            }
-        }
-    }
+  let moved = false;
 
-    // Check if the grid changed
+  if (direction === 'left' || direction === 'right') {
+    const reverse = direction === 'right';
     for (let i = 0; i < GRID_SIZE; i++) {
-        for (let j = 0; j < GRID_SIZE; j++) {
-            if (grid[i][j] !== tempGrid[i][j]) {
-                moved = true;
-                break;
-            }
+      const rowTiles = tiles
+        .filter((t) => t.row === i)
+        .sort((a, b) => (reverse ? b.col - a.col : a.col - b.col));
+      let target = reverse ? GRID_SIZE - 1 : 0;
+      let last = null;
+      rowTiles.forEach((tile) => {
+        if (last && tile.value === last.value && !last.merged) {
+          last.value *= 2;
+          last.merged = true;
+          score += last.value;
+          tile.toRemove = true;
+          tile.targetRow = i;
+          tile.targetCol = last.targetCol;
+          moved = moved || tile.col !== last.targetCol;
+        } else {
+          tile.targetRow = i;
+          tile.targetCol = target;
+          moved = moved || tile.col !== target;
+          last = tile;
+          target += reverse ? -1 : 1;
         }
+      });
     }
+  } else if (direction === 'up' || direction === 'down') {
+    const reverse = direction === 'down';
+    for (let j = 0; j < GRID_SIZE; j++) {
+      const colTiles = tiles
+        .filter((t) => t.col === j)
+        .sort((a, b) => (reverse ? b.row - a.row : a.row - b.row));
+      let target = reverse ? GRID_SIZE - 1 : 0;
+      let last = null;
+      colTiles.forEach((tile) => {
+        if (last && tile.value === last.value && !last.merged) {
+          last.value *= 2;
+          last.merged = true;
+          score += last.value;
+          tile.toRemove = true;
+          tile.targetRow = last.targetRow;
+          tile.targetCol = j;
+          moved = moved || tile.row !== last.targetRow;
+        } else {
+          tile.targetRow = target;
+          tile.targetCol = j;
+          moved = moved || tile.row !== target;
+          last = tile;
+          target += reverse ? -1 : 1;
+        }
+      });
+    }
+  }
 
-    if (moved) {
-        addNewTile();
-        updateDisplay();
+  if (!moved) return;
+
+  resetGrid();
+
+  tiles.forEach((tile) => {
+    if (!tile.toRemove) {
+      tile.row = tile.targetRow;
+      tile.col = tile.targetCol;
+      grid[tile.row][tile.col] = tile.value;
     }
+    positionTile(tile.element, tile.targetRow, tile.targetCol);
+    if (tile.toRemove) {
+      tile.element.addEventListener(
+        'transitionend',
+        () => tile.element.remove(),
+        { once: true }
+      );
+    } else {
+      tile.element.dataset.value = tile.value;
+      tile.element.textContent = tile.value;
+    }
+  });
+
+  tiles = tiles.filter((t) => !t.toRemove);
+
+  setTimeout(() => {
+    spawnTile();
+    updateScore();
+  }, 150);
 }
 
 function handleKeyPress(event) {
-    switch(event.key) {
-        case 'ArrowLeft':
-            move('left');
-            break;
-        case 'ArrowRight':
-            move('right');
-            break;
-        case 'ArrowUp':
-            move('up');
-            break;
-        case 'ArrowDown':
-            move('down');
-            break;
-    }
+  switch (event.key) {
+    case 'ArrowLeft':
+      move('left');
+      break;
+    case 'ArrowRight':
+      move('right');
+      break;
+    case 'ArrowUp':
+      move('up');
+      break;
+    case 'ArrowDown':
+      move('down');
+      break;
+  }
 }
 
-// Initialize game
-createTiles();
+function init() {
+  resetGrid();
+  createGrid();
+  spawnTile();
+  spawnTile();
+  updateScore();
+}
+
 document.addEventListener('keydown', handleKeyPress);
-addNewTile();
-addNewTile();
-updateDisplay();
+init();

--- a/style.css
+++ b/style.css
@@ -22,13 +22,30 @@ body {
     margin: 0 auto;
 }
 
-.tile-container {
+.grid-container {
     display: grid;
     grid-template-columns: repeat(5, 80px);
     grid-template-rows: repeat(5, 80px);
-    grid-gap: 10px;
+    gap: 10px;
     background-color: #bbada0;
     padding: 10px;
+    position: relative;
+}
+
+.tile-container {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 440px;
+    height: 440px;
+    pointer-events: none;
+}
+
+.cell {
+    width: 80px;
+    height: 80px;
+    background-color: #cdc1b4;
+    border-radius: 3px;
 }
 
 .tile {


### PR DESCRIPTION
## Summary
- restructure board markup to separate grid from moving tiles
- adjust styles for absolute-positioned tiles
- reimplement game logic to animate tile movement and merging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846ae6f7ff48323a0b351cb256a45b6