### PR TITLE
Ensure tiles render above grid cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
         <div class="score-container">
             <h2>Score: <span id="score">0</span></h2>
         </div>
-        <div class="grid-container" id="grid-container"></div>
-        <div class="tile-container" id="tile-container"></div>
+        <div class="grid-container" id="grid-container">
+            <div class="tile-container" id="tile-container"></div>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -35,11 +35,10 @@ body {
 
 .tile-container {
     position: absolute;
-    top: 70px;
-    left: 25px;
-    width: 440px;
-    height: 440px;
+    inset: 0;
+    padding: 10px;
     pointer-events: none;
+    z-index: 1;
 }
 
 .cell {
@@ -50,6 +49,7 @@ body {
 }
 
 .tile {
+    position: absolute;
     width: 80px;
     height: 80px;
     background-color: #eee4da;


### PR DESCRIPTION
## Summary
- ensure the tile overlay has a higher stacking order so tiles render above the background grid

## Testing
- npm test *(fails: missing package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f38d819188323b14bf806fd6d65c8)